### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Pkg.add("Distributions")
 Pkg.add("DataFrames")
 Pkg.add("CSVFiles")
 Pkg.add("RCall")
+
+Pkg.pin("Mimi", v"0.4.1")
 ````
 
 On the R side of things you also need to install a number packages,
@@ -32,7 +34,7 @@ run the following:
 install.packages("tidyverse")
 ````
 
-You also need to download the file ``Rallfun-v34.txt`` from
+You also need to download the file ``Rallfun-v35.txt`` from
 [here](https://dornsife.usc.edu/assets/sites/239/docs/Rallfun-v35.txt) and
 place it in the ``src`` folder.
 
@@ -43,7 +45,7 @@ git ``--recurse-submodules`` option when cloning the repository.
 That is, you can clone the repository from the command-line with:
 
 ```sh
-git clone --recurse-submodules https://github.com/anthofflab/mimi-page.jl.git
+git clone --recurse-submodules https://github.com/anthofflab/paper-2018-mimi-page-replication.jl.git
 ```
 
 If you cloned the repository without that option, you can issue the

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Assessment Model".
 
 ## Software requirements
 
-You need to install [Julia](http://julialang.org/)
-and [R](https://www.r-project.org/) to run the replication code.
+To run the replication code, you need to install:
+- version v0.6.4 of [Julia](https://julialang.org/downloads/oldreleases.html)
+- and [R](https://www.r-project.org/)
 
 ## Preparing the software environment
 


### PR DESCRIPTION
I just tried to clone and run this code, and I needed to make a few changes:
- pin Mimi to v0.4.1
- specify that it has to be run with Julia v0.6 (not later versions)
- for cloning the repo with submodules recursively, I change the URL to be the parent repo
- fix typo Rallfun-v34.txt -> Rallfun-v35.txt

I'm not sure if any/all of these changes are necessary or done in the best way, but wanted to draw attention to it from my replication experience!